### PR TITLE
Add Windows RMM agent worker service and MSI packaging assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # test22
+
+This repository now includes a production-ready Remote Monitoring and Management (RMM) Windows agent alongside the sample front-end assets. The agent is implemented as a .NET 6 worker service that runs as a Windows Service, publishes device health metrics to your cloud RMM endpoint, and can be packaged into an MSI for streamlined deployment.
+
+## Cloud RMM Agent
+
+The agent source code lives in [`rmm-agent/AgentService`](rmm-agent/AgentService). Key features include:
+
+- Configurable cloud endpoint URL, agent identifier, API key, and heartbeat frequency via `appsettings.json` or an optional `config.json` override file.
+- Heartbeat payload with device name, OS details, uptime, CPU load, memory usage, fixed-disk capacity, and (optionally) the top-level process list.
+- Resilient HTTP client with retry logic and structured logging.
+
+### Building
+
+```bash
+dotnet restore rmm-agent/AgentService/AgentService.csproj
+dotnet publish rmm-agent/AgentService/AgentService.csproj -c Release -r win-x64 --self-contained false
+```
+
+### MSI packaging
+
+Instructions for bundling the agent into an MSI installer are provided in [`rmm-agent/installer/README.md`](rmm-agent/installer/README.md). The WiX definition (`CloudRmmAgent.wxs`) installs the service, copies configuration files, and supports silent deployment for remote rollouts.

--- a/rmm-agent/AgentService/AgentClient.cs
+++ b/rmm-agent/AgentService/AgentClient.cs
@@ -1,0 +1,56 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Extensions.Http;
+
+namespace RmmAgent;
+
+public class AgentClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<AgentClient> _logger;
+
+    public AgentClient(HttpClient httpClient, ILogger<AgentClient> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public async Task SendHeartbeatAsync(AgentConfig config, AgentPayload payload, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(new Uri(config.ServerUrl), "/api/agents/heartbeat"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        if (!string.IsNullOrWhiteSpace(config.ApiKey))
+        {
+            request.Headers.Add("X-API-KEY", config.ApiKey);
+        }
+
+        var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        });
+
+        request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException($"Server returned {(int)response.StatusCode}: {response.ReasonPhrase}. Content: {content}");
+        }
+
+        _logger.LogDebug("Server response: {StatusCode}", response.StatusCode);
+    }
+
+    public static IAsyncPolicy<HttpResponseMessage> CreateRetryPolicy()
+    {
+        return HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .OrResult(message => (int)message.StatusCode >= 500)
+            .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+    }
+}

--- a/rmm-agent/AgentService/AgentConfig.cs
+++ b/rmm-agent/AgentService/AgentConfig.cs
@@ -1,0 +1,16 @@
+namespace RmmAgent;
+
+public class AgentConfig
+{
+    public string ServerUrl { get; set; } = string.Empty;
+
+    public string AgentId { get; set; } = string.Empty;
+
+    public string? ApiKey { get; set; }
+
+    public int HeartbeatIntervalSeconds { get; set; } = 60;
+
+    public bool CollectProcesses { get; set; } = false;
+
+    public string ConfigFilePath { get; set; } = "config.json";
+}

--- a/rmm-agent/AgentService/AgentPayload.cs
+++ b/rmm-agent/AgentService/AgentPayload.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace RmmAgent;
+
+public record AgentPayload
+{
+    public required string AgentId { get; init; }
+    public required DateTime TimestampUtc { get; init; }
+    public required SystemSnapshot Snapshot { get; init; }
+}
+
+public record SystemSnapshot
+{
+    public required string MachineName { get; init; }
+    public required string OperatingSystem { get; init; }
+    public required string Architecture { get; init; }
+    public required TimeSpan Uptime { get; init; }
+    public required double CpuLoadPercentage { get; init; }
+    public required double MemoryUsedMb { get; init; }
+    public required double MemoryTotalMb { get; init; }
+    public required IEnumerable<DiskSnapshot> Disks { get; init; }
+    public required IEnumerable<ProcessSnapshot>? Processes { get; init; }
+}
+
+public record DiskSnapshot
+{
+    public required string Name { get; init; }
+    public required double TotalGb { get; init; }
+    public required double FreeGb { get; init; }
+}
+
+public record ProcessSnapshot
+{
+    public required int Pid { get; init; }
+    public required string Name { get; init; }
+    public required double MemoryMb { get; init; }
+}

--- a/rmm-agent/AgentService/AgentService.csproj
+++ b/rmm-agent/AgentService/AgentService.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>RmmAgent</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />
+    <PackageReference Include="System.Management" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.20" />
+  </ItemGroup>
+</Project>

--- a/rmm-agent/AgentService/AgentWorker.cs
+++ b/rmm-agent/AgentService/AgentWorker.cs
@@ -1,0 +1,106 @@
+using System.IO;
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RmmAgent;
+
+public class AgentWorker : BackgroundService
+{
+    private readonly AgentClient _client;
+    private readonly ILogger<AgentWorker> _logger;
+    private readonly IHostEnvironment _hostEnvironment;
+    private readonly SystemInfoCollector _systemInfoCollector;
+    private AgentConfig _config;
+
+    public AgentWorker(
+        AgentClient client,
+        IOptionsMonitor<AgentConfig> optionsMonitor,
+        ILogger<AgentWorker> logger,
+        IHostEnvironment hostEnvironment,
+        SystemInfoCollector systemInfoCollector)
+    {
+        _client = client;
+        _logger = logger;
+        _hostEnvironment = hostEnvironment;
+        _systemInfoCollector = systemInfoCollector;
+        _config = optionsMonitor.CurrentValue;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Starting RMM agent with id {AgentId}", _config.AgentId);
+        await LoadExternalConfigAsync(stoppingToken);
+
+        if (string.IsNullOrWhiteSpace(_config.ServerUrl) || string.IsNullOrWhiteSpace(_config.AgentId))
+        {
+            _logger.LogCritical("ServerUrl and AgentId must be configured before the agent can start");
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var payload = await _systemInfoCollector.CreatePayloadAsync(_config, stoppingToken);
+                await _client.SendHeartbeatAsync(_config, payload, stoppingToken);
+                _logger.LogInformation("Heartbeat sent to {ServerUrl}", _config.ServerUrl);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to send heartbeat");
+            }
+
+            var delay = TimeSpan.FromSeconds(Math.Max(15, _config.HeartbeatIntervalSeconds));
+            await Task.Delay(delay, stoppingToken);
+        }
+    }
+
+    private async Task LoadExternalConfigAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var basePath = Path.GetDirectoryName(_hostEnvironment?.ContentRootPath ?? AppContext.BaseDirectory) ?? AppContext.BaseDirectory;
+            var configPath = Path.Combine(basePath, _config.ConfigFilePath);
+
+            if (!File.Exists(configPath))
+            {
+                _logger.LogWarning("Configuration file {ConfigPath} not found. Using default configuration.", configPath);
+                return;
+            }
+
+            await using var stream = File.OpenRead(configPath);
+            var config = await JsonSerializer.DeserializeAsync<AgentConfig>(stream, cancellationToken: cancellationToken);
+            if (config is null)
+            {
+                _logger.LogWarning("Configuration file {ConfigPath} is empty or invalid", configPath);
+                return;
+            }
+
+            _config = MergeConfigs(_config, config);
+            _logger.LogInformation("Loaded configuration overrides from {ConfigPath}", configPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unable to read configuration overrides");
+        }
+    }
+
+    private static AgentConfig MergeConfigs(AgentConfig baseConfig, AgentConfig overrides)
+    {
+        return new AgentConfig
+        {
+            ServerUrl = string.IsNullOrWhiteSpace(overrides.ServerUrl) ? baseConfig.ServerUrl : overrides.ServerUrl,
+            AgentId = string.IsNullOrWhiteSpace(overrides.AgentId) ? baseConfig.AgentId : overrides.AgentId,
+            ApiKey = string.IsNullOrWhiteSpace(overrides.ApiKey) ? baseConfig.ApiKey : overrides.ApiKey,
+            HeartbeatIntervalSeconds = overrides.HeartbeatIntervalSeconds > 0 ? overrides.HeartbeatIntervalSeconds : baseConfig.HeartbeatIntervalSeconds,
+            CollectProcesses = overrides.CollectProcesses,
+            ConfigFilePath = string.IsNullOrWhiteSpace(overrides.ConfigFilePath) ? baseConfig.ConfigFilePath : overrides.ConfigFilePath
+        };
+    }
+}

--- a/rmm-agent/AgentService/Program.cs
+++ b/rmm-agent/AgentService/Program.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace RmmAgent;
+
+public static class Program
+{
+    public static async Task Main(string[] args)
+    {
+        using IHost host = Host.CreateDefaultBuilder(args)
+            .UseWindowsService(options => { options.ServiceName = "CloudRmmAgent"; })
+            .ConfigureServices((context, services) =>
+            {
+                services.Configure<AgentConfig>(context.Configuration.GetSection("Agent"));
+                services.AddHttpClient<AgentClient>()
+                    .AddPolicyHandler(AgentClient.CreateRetryPolicy());
+                services.AddSingleton<AgentClient>();
+                services.AddSingleton<SystemInfoCollector>();
+                services.AddHostedService<AgentWorker>();
+            })
+            .ConfigureLogging(logging =>
+            {
+                logging.ClearProviders();
+                logging.AddSimpleConsole(options =>
+                {
+                    options.TimestampFormat = "yyyy-MM-dd HH:mm:ss ";
+                });
+            })
+            .Build();
+
+        await host.RunAsync();
+    }
+}

--- a/rmm-agent/AgentService/SystemInfoCollector.cs
+++ b/rmm-agent/AgentService/SystemInfoCollector.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Management;
+using System.Runtime.InteropServices;
+
+namespace RmmAgent;
+
+public class SystemInfoCollector
+{
+    public async Task<AgentPayload> CreatePayloadAsync(AgentConfig config, CancellationToken cancellationToken)
+    {
+        var memory = GetMemoryInfo();
+        var snapshot = new SystemSnapshot
+        {
+            MachineName = Environment.MachineName,
+            OperatingSystem = GetOperatingSystem(),
+            Architecture = RuntimeInformation.OSArchitecture.ToString(),
+            Uptime = GetSystemUptime(),
+            CpuLoadPercentage = await GetCpuLoadAsync(cancellationToken),
+            MemoryUsedMb = memory.used,
+            MemoryTotalMb = memory.total,
+            Disks = GetDiskSnapshots().ToArray(),
+            Processes = config.CollectProcesses ? GetProcessSnapshots().ToArray() : null
+        };
+
+        return new AgentPayload
+        {
+            AgentId = config.AgentId,
+            TimestampUtc = DateTime.UtcNow,
+            Snapshot = snapshot
+        };
+    }
+
+    private static string GetOperatingSystem()
+    {
+        return $"{Environment.OSVersion.Platform} {Environment.OSVersion.VersionString}";
+    }
+
+    private static TimeSpan GetSystemUptime()
+    {
+        try
+        {
+            using var uptime = new PerformanceCounter("System", "System Up Time");
+            uptime.NextValue();
+            return TimeSpan.FromSeconds(uptime.NextValue());
+        }
+        catch
+        {
+            return TimeSpan.Zero;
+        }
+    }
+
+    private static async Task<double> GetCpuLoadAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var cpuCounter = new PerformanceCounter("Processor", "% Processor Time", "_Total");
+            cpuCounter.NextValue();
+            await Task.Delay(1000, cancellationToken);
+            return Math.Round(cpuCounter.NextValue(), 2);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private static (double used, double total) GetMemoryInfo()
+    {
+        try
+        {
+            using var searcher = new ManagementObjectSearcher("SELECT TotalVisibleMemorySize, FreePhysicalMemory FROM Win32_OperatingSystem");
+            foreach (var obj in searcher.Get().Cast<ManagementObject>())
+            {
+                var totalKb = Convert.ToDouble(obj["TotalVisibleMemorySize"]);
+                var freeKb = Convert.ToDouble(obj["FreePhysicalMemory"]);
+                var totalMb = totalKb / 1024;
+                var usedMb = (totalKb - freeKb) / 1024;
+                return (Math.Round(usedMb, 2), Math.Round(totalMb, 2));
+            }
+        }
+        catch
+        {
+        }
+
+        return (0, 0);
+    }
+
+    private static IEnumerable<DiskSnapshot> GetDiskSnapshots()
+    {
+        var drives = DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.Fixed && d.IsReady);
+        foreach (var drive in drives)
+        {
+            var totalGb = Math.Round(drive.TotalSize / 1024d / 1024d / 1024d, 2);
+            var freeGb = Math.Round(drive.TotalFreeSpace / 1024d / 1024d / 1024d, 2);
+            yield return new DiskSnapshot
+            {
+                Name = drive.Name,
+                TotalGb = totalGb,
+                FreeGb = freeGb
+            };
+        }
+    }
+
+    private static IEnumerable<ProcessSnapshot> GetProcessSnapshots()
+    {
+        foreach (var process in Process.GetProcesses())
+        {
+            double memoryMb = 0;
+            try
+            {
+                memoryMb = Math.Round(process.WorkingSet64 / 1024d / 1024d, 2);
+            }
+            catch
+            {
+            }
+
+            yield return new ProcessSnapshot
+            {
+                Pid = process.Id,
+                Name = process.ProcessName,
+                MemoryMb = memoryMb
+            };
+        }
+    }
+}

--- a/rmm-agent/AgentService/appsettings.json
+++ b/rmm-agent/AgentService/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "Agent": {
+    "ServerUrl": "https://your-cloud-rmm.example.com",
+    "AgentId": "AGENT-0001",
+    "ApiKey": "replace-with-api-key",
+    "HeartbeatIntervalSeconds": 60,
+    "CollectProcesses": false,
+    "ConfigFilePath": "config.json"
+  }
+}

--- a/rmm-agent/AgentService/config.example.json
+++ b/rmm-agent/AgentService/config.example.json
@@ -1,0 +1,7 @@
+{
+  "ServerUrl": "https://your-cloud-rmm.example.com",
+  "AgentId": "AGENT-0001",
+  "ApiKey": "replace-with-api-key",
+  "HeartbeatIntervalSeconds": 60,
+  "CollectProcesses": false
+}

--- a/rmm-agent/installer/CloudRmmAgent.wxs
+++ b/rmm-agent/installer/CloudRmmAgent.wxs
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*"
+           Name="Cloud RMM Agent"
+           Language="1033"
+           Version="1.0.0.0"
+           Manufacturer="Example Corp"
+           UpgradeCode="1E3CFB0C-45D7-4BF6-8D87-E61F90C12216">
+    <Package InstallerVersion="500"
+             Compressed="yes"
+             InstallScope="perMachine"
+             Description="Cloud RMM Windows Agent" />
+
+    <MajorUpgrade Schedule="afterInstallInitialize" DowngradeErrorMessage="A newer version of the Cloud RMM Agent is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <Feature Id="MainFeature" Title="Cloud RMM Agent" Level="1">
+      <ComponentGroupRef Id="AgentComponents" />
+    </Feature>
+  </Product>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFiles64Folder">
+        <Directory Id="INSTALLFOLDER" Name="Cloud RMM Agent" />
+      </Directory>
+    </Directory>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="AgentComponents">
+      <Component Id="cmpAgentExecutable" Guid="D76CD7F6-91B1-4A4D-B075-F7D4D4C2A8E9">
+        <File Id="filAgentExecutable"
+              KeyPath="yes"
+              Source="$(var.PublishFolder)\\CloudRmmAgent.exe"
+              Checksum="yes">
+          <ServiceInstall Id="svcInstall"
+                           Name="CloudRmmAgent"
+                           DisplayName="Cloud RMM Agent"
+                           Description="Reports device health to the Cloud RMM platform"
+                           Start="auto"
+                           Type="ownProcess"
+                           ErrorControl="normal"
+                           Vital="yes"
+                           Account="LocalSystem" />
+          <ServiceControl Id="svcControl"
+                           Name="CloudRmmAgent"
+                           Start="install"
+                           Stop="both"
+                           Remove="uninstall"
+                           Wait="yes" />
+        </File>
+      </Component>
+
+      <Component Id="cmpAppSettings" Guid="E927AD18-CF82-4E69-99C7-5F90CB12AFB3">
+        <File Id="filAppSettings"
+              Source="$(var.PublishFolder)\\appsettings.json"
+              KeyPath="yes" />
+      </Component>
+
+      <Component Id="cmpConfigTemplate" Guid="83D86E3F-6BA5-41C0-BAC6-6CD64A63A323">
+        <File Id="filConfigTemplate"
+              Source="$(var.PublishFolder)\\config.example.json"
+              KeyPath="yes" />
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/rmm-agent/installer/README.md
+++ b/rmm-agent/installer/README.md
@@ -1,0 +1,38 @@
+# Cloud RMM Agent MSI Packaging
+
+The Windows agent is published as a `net6.0` worker service that can run as a Windows Service. Use the WiX Toolset to create an MSI installer that installs and registers the service.
+
+## Prerequisites
+
+1. Install [.NET 6 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0).
+2. Install [WiX Toolset 3.11](https://wixtoolset.org/releases/) and ensure `candle.exe` and `light.exe` are on your `PATH`.
+
+## Build and publish the agent
+
+```powershell
+# From the repository root
+$publishDir = "$PSScriptRoot/../publish"
+dotnet publish ../AgentService/AgentService.csproj -c Release -r win-x64 -o $publishDir --self-contained false
+```
+
+Copy `config.example.json` to `config.json` and update the settings if you want default overrides baked into the installer.
+
+## Build the MSI
+
+```powershell
+$publishDir = Resolve-Path "$PSScriptRoot/../publish"
+$wxs = Resolve-Path "$PSScriptRoot/CloudRmmAgent.wxs"
+
+candle.exe -dPublishFolder=$publishDir.FullName $wxs -out "$PSScriptRoot/CloudRmmAgent.wixobj"
+light.exe "$PSScriptRoot/CloudRmmAgent.wixobj" -ext WixUtilExtension.dll -out "$PSScriptRoot/CloudRmmAgent.msi"
+```
+
+The resulting `CloudRmmAgent.msi` installs the service to `C:\Program Files\Cloud RMM Agent`. During installation, the service is started automatically and continues to run on startup.
+
+## Silent installation
+
+```powershell
+msiexec /i CloudRmmAgent.msi /qn /l*v install.log
+```
+
+Use the `/qn` flag for a completely silent deployment suitable for remote management tools.


### PR DESCRIPTION
## Summary
- add a .NET 6 Windows worker service that reports device health to a configurable cloud RMM endpoint
- capture system metrics and deliver them in structured heartbeat payloads with retry-capable HTTP delivery
- provide WiX installer definition and packaging guide for building an MSI-based service installer

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68ff25ffa9d483309e67499cadcba964